### PR TITLE
crypto-helper: Add Decimal and Binary byte formats

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -44,3 +44,35 @@ pub fn decode_base64(input: &str) -> Result<Vec<u8>, String> {
         base64::decode(input).map_err(|err| format!("invalid base64: {:?}", err))
     }
 }
+
+pub fn decode_decimal(input: &str) -> Result<Vec<u8>, String> {
+    input
+        .chars()
+        .filter(|c| c.is_ascii_digit() || c.is_whitespace())
+        .collect::<String>()
+        .split_whitespace()
+        .map(|s| {
+            s.parse::<u8>()
+                .map_err(|err| format!("invalid decimal input: {:?}", err))
+        })
+        .collect::<Result<Vec<u8>, String>>()
+}
+
+pub fn decode_binary(input: &str) -> Result<Vec<u8>, String> {
+    let binary_str = input.chars().filter(|c| c == &'0' || c == &'1').collect::<String>();
+
+    if binary_str.len() % 8 != 0 {
+        return Err("invalid binary input: not a multiple of 8 bits".to_string());
+    }
+
+    binary_str
+        .as_str()
+        .chars()
+        .collect::<Vec<char>>()
+        .chunks(8)
+        .map(|chunk| {
+            let s: String = chunk.iter().collect();
+            u8::from_str_radix(&s, 2).map_err(|err| format!("invalid binary input: {:?}", err))
+        })
+        .collect::<Result<Vec<u8>, String>>()
+}


### PR DESCRIPTION
1. Update BytesFormat enum.
2. Update AsRef<str> and From<&BytesFormat> for BytesFormat implementations to handle Decimal and Binary formats.
3. Extend BYTES_FORMATS array to include Decimal and Binary formats.
4. Implement encode_bytes() function for Decimal and Binary formats.
5. Create separate decode_decimal() and decode_binary() functions for parsing Decimal and Binary byte formats.
6. Update parse_bytes() function to use the new decode_decimal() and decode_binary() functions.
7. Refactor code for improved modularity and maintainability.

Fixes: ISSUE #16 

https://user-images.githubusercontent.com/64846852/231808884-a6247fb3-71f0-4286-842a-3dd23a906ad5.mov
