### PR TITLE
ByteInput: input filtering

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -12,7 +12,13 @@ pub use switch::{Switch, SwitchProps};
 use web_sys::MouseEvent;
 use yew::{classes, Callback, Classes, UseStateSetter};
 
-use crate::utils::{decode_binary, decode_decimal};
+use crate::utils::{decode_base64, decode_binary, decode_decimal};
+
+const HEX: &str = "hex";
+const BASE64: &str = "base64";
+const ASCII: &str = "ascii";
+const DECIMAL: &str = "decimal";
+const BINARY: &str = "binary";
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]
 pub enum BytesFormat {
@@ -27,11 +33,11 @@ pub enum BytesFormat {
 impl AsRef<str> for BytesFormat {
     fn as_ref(&self) -> &str {
         match self {
-            BytesFormat::Hex => "hex",
-            BytesFormat::Base64 => "base64",
-            BytesFormat::Ascii => "ascii",
-            BytesFormat::Decimal => "decimal",
-            BytesFormat::Binary => "binary",
+            BytesFormat::Hex => HEX,
+            BytesFormat::Base64 => BASE64,
+            BytesFormat::Ascii => ASCII,
+            BytesFormat::Decimal => DECIMAL,
+            BytesFormat::Binary => BINARY,
         }
     }
 }
@@ -39,11 +45,11 @@ impl AsRef<str> for BytesFormat {
 impl From<&BytesFormat> for &str {
     fn from(format: &BytesFormat) -> Self {
         match format {
-            BytesFormat::Hex => "hex",
-            BytesFormat::Base64 => "base64",
-            BytesFormat::Ascii => "ascii",
-            BytesFormat::Decimal => "decimal",
-            BytesFormat::Binary => "binary",
+            BytesFormat::Hex => HEX,
+            BytesFormat::Base64 => BASE64,
+            BytesFormat::Ascii => ASCII,
+            BytesFormat::Decimal => DECIMAL,
+            BytesFormat::Binary => BINARY,
         }
     }
 }
@@ -78,8 +84,31 @@ fn encode_bytes(bytes: impl AsRef<[u8]>, format: BytesFormat) -> String {
 
 fn parse_bytes(raw: &str, format: BytesFormat) -> Result<Vec<u8>, String> {
     match format {
-        BytesFormat::Hex => hex::decode(raw).map_err(|err| format!("invalid hex input:{:?}", err)),
-        BytesFormat::Base64 => base64::decode(raw).map_err(|err| format!("invalid base64 input:{:?}", err)),
+        BytesFormat::Hex => {
+            let raw = raw
+                .to_ascii_lowercase()
+                .chars()
+                .filter(|c| ('0'..='9').contains(c) || ('a'..='f').contains(c))
+                .collect::<String>();
+            hex::decode(raw).map_err(|err| format!("invalid hex input: {:?}", err))
+        }
+        BytesFormat::Base64 => {
+            let raw = raw
+                .chars()
+                .filter(|c| {
+                    ('a'..='z').contains(c)
+                        || ('A'..='Z').contains(c)
+                        || ('0'..='9').contains(c)
+                        || *c == '+'
+                        || *c == '/'
+                        || *c == '='
+                        // url-encoded base64:
+                        || *c == '-'
+                        || *c == '_'
+                })
+                .collect::<String>();
+            decode_base64(&raw)
+        }
         BytesFormat::Ascii => Ok(raw.into()),
         BytesFormat::Decimal => decode_decimal(raw),
         BytesFormat::Binary => decode_binary(raw),

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -88,7 +88,7 @@ fn parse_bytes(raw: &str, format: BytesFormat) -> Result<Vec<u8>, String> {
             let raw = raw
                 .to_ascii_lowercase()
                 .chars()
-                .filter(|c| ('0'..='9').contains(c) || ('a'..='f').contains(c))
+                .filter(|c| c.is_ascii_digit() || ('a'..='f').contains(c))
                 .collect::<String>();
             hex::decode(raw).map_err(|err| format!("invalid hex input: {:?}", err))
         }
@@ -96,9 +96,9 @@ fn parse_bytes(raw: &str, format: BytesFormat) -> Result<Vec<u8>, String> {
             let raw = raw
                 .chars()
                 .filter(|c| {
-                    ('a'..='z').contains(c)
-                        || ('A'..='Z').contains(c)
-                        || ('0'..='9').contains(c)
+                    c.is_ascii_lowercase()
+                        || c.is_ascii_uppercase()
+                        || c.is_ascii_digit()
                         || *c == '+'
                         || *c == '/'
                         || *c == '='

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -50,7 +50,7 @@ pub fn decode_decimal(input: &str) -> Result<Vec<u8>, String> {
 }
 
 pub fn decode_binary(input: &str) -> Result<Vec<u8>, String> {
-    let binary_str = input.chars().filter(|c| c == &'0' || c == &'1').collect::<String>();
+    let binary_str = input.chars().filter(|c| *c == '0' || *c == '1').collect::<String>();
 
     if binary_str.len() % 8 != 0 {
         return Err("invalid binary input: not a multiple of 8 bits".to_string());


### PR DESCRIPTION
- [x] filter non-hex chars.
- [x] filter non-base64 chars.
- [x] base64 url-encoded support.