### PR TITLE
ASN1: Rendering improvements

### DIFF
--- a/public/styles/asn1/node.scss
+++ b/public/styles/asn1/node.scss
@@ -4,7 +4,7 @@
     gap: 0.2em;
     align-items: center;
     cursor: crosshair;
-    width: 100%;
+    width: calc(100% - 0.5em);
 }
 
 .asn1-constructor-header {
@@ -37,6 +37,7 @@
     background-color: #aab7ce;
     font-size: 0.7em;
     overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .asn-bool-true {

--- a/public/styles/asn1/page.scss
+++ b/public/styles/asn1/page.scss
@@ -8,6 +8,6 @@
 .asn1-viewers {
     display: grid;
     grid-template-columns: 70% auto;
-    gap: 0.1em;
+    gap: 0.7em;
     width: 100%;
 }

--- a/src/asn1/hex_view.rs
+++ b/src/asn1/hex_view.rs
@@ -176,7 +176,10 @@ fn build_data_bytes(
         Asn1Type::VisibleString(_) => default_bytes(asn1_node_id, cur_node, set_cur_node, asn1, bytes, select_all),
         Asn1Type::UtcTime(_) => default_bytes(asn1_node_id, cur_node, set_cur_node, asn1, bytes, select_all),
         Asn1Type::GeneralizedTime(_) => default_bytes(asn1_node_id, cur_node, set_cur_node, asn1, bytes, select_all),
-        Asn1Type::BitString(_) => default_bytes(asn1_node_id, cur_node, set_cur_node, asn1, bytes, select_all),
+        Asn1Type::BitString(bit) => match bit.inner() {
+            Some(asn1) => build_hex_bytes(asn1, cur_node, set_cur_node.clone(), bytes, select_all),
+            None => default_bytes(asn1_node_id, cur_node, set_cur_node, asn1, bytes, select_all),
+        },
         Asn1Type::BmpString(_) => default_bytes(asn1_node_id, cur_node, set_cur_node, asn1, bytes, select_all),
         Asn1Type::Bool(_) => default_bytes(asn1_node_id, cur_node, set_cur_node, asn1, bytes, select_all),
         Asn1Type::Null(_) => default_bytes(asn1_node_id, cur_node, set_cur_node, asn1, bytes, select_all),

--- a/src/asn1/scheme/strings.rs
+++ b/src/asn1/scheme/strings.rs
@@ -26,7 +26,7 @@ pub fn octet_string(props: &OctetStringNodeProps) -> Html {
 
     match props.node.inner() {
         Some(asn1) => html! {
-            <div style="cursor: crosshair">
+            <div style="cursor: crosshair; width: 100%;">
                 <div class="asn1-constructor-header">
                     <NodeOptions node_bytes={props.meta.raw_bytes().to_vec()} {offset} {length_len} {data_len} name={String::from("OctetString")}/>
                     <span class="asn1-node-info-label">{format!("({} bytes)", octets.len())}</span>
@@ -77,7 +77,7 @@ pub fn bit_string(props: &BitStringNodeProps) -> Html {
 
     match props.node.inner() {
         Some(asn1) => html! {
-            <div style="cursor: crosshair">
+            <div style="cursor: crosshair; width: 100%;">
                 <div class="asn1-constructor-header">
                     <NodeOptions node_bytes={props.meta.raw_bytes().to_vec()} {offset} {length_len} {data_len} name={String::from("BitString")} />
                     <span class="asn1-node-info-label">{format!("({} bits)", bits_amount)}</span>

--- a/src/crypto_helper.rs
+++ b/src/crypto_helper.rs
@@ -4,7 +4,7 @@ mod info;
 mod input;
 mod macros;
 mod output;
-mod serde;
+pub mod serde;
 
 pub use algorithm::Algorithm;
 use info::Info;

--- a/src/url_query_params.rs
+++ b/src/url_query_params.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+use crate::crypto_helper::serde::{deserialize_bytes, serialize_bytes};
 use crate::crypto_helper::Algorithm;
 
 const APP_HOST: &str = env!("APP_HOST");
@@ -23,6 +24,21 @@ pub fn generate_jwt_link(jwt: String) -> String {
 
     link.push_str("/jwt/?");
     link.push_str(&serde_qs::to_string(&Jwt { jwt }).unwrap());
+
+    link
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Asn1 {
+    #[serde(serialize_with = "serialize_bytes", deserialize_with = "deserialize_bytes")]
+    pub asn1: Vec<u8>,
+}
+
+pub fn generate_asn1_link(asn1: Vec<u8>) -> String {
+    let mut link = APP_HOST.to_string();
+
+    link.push_str("/asn1/?");
+    link.push_str(&serde_qs::to_string(&Asn1 { asn1 }).unwrap());
 
     link
 }


### PR DESCRIPTION
* render the `BitString` inner structure in a hex editor (if present).
* share asn1 by URL.
* bigger gap between tree and hex views.
* fix wide elements rendering.
* fix the width of some elements.