### PR TITLE
fix(issue-88): Fix decoding asn1 code with empty bitstring

### DIFF
--- a/crates/asn1-parser/src/string/bit_string.rs
+++ b/crates/asn1-parser/src/string/bit_string.rs
@@ -32,7 +32,14 @@ impl BitString<'_> {
     }
 
     pub fn bits_amount(&self) -> usize {
-        (self.octets.as_ref().len() - 1) * 8 - usize::from(self.octets.as_ref()[0])
+        if self.octets.is_empty() {
+            return 0;
+        }
+
+        let data_len = self.octets.len() - 1;
+        let padding = usize::from(self.octets[0]);
+
+        (data_len * 8).saturating_sub(padding)
     }
 
     /// Creates a new [BitString] from amount of bits and actual bits buffer
@@ -100,7 +107,12 @@ impl<'data> Asn1ValueDecoder<'data> for BitString<'data> {
     fn decode(_: Tag, reader: &mut Reader<'data>) -> Asn1Result<Self> {
         let data = reader.read_remaining();
 
-        let inner = if !data.is_empty() {
+        if data.is_empty() {
+            return Err(Error::from("BitString must have at least one byte (unused bits)"));
+        }
+
+        let inner = if data.len() > 1 {
+            // Check len > 1 since first byte is unused bits
             let mut inner_reader = Reader::new(&data[1..]);
             inner_reader.set_next_id(reader.next_id());
             inner_reader.set_offset(reader.full_offset() - data.len());

--- a/crates/asn1-parser/src/string/bit_string.rs
+++ b/crates/asn1-parser/src/string/bit_string.rs
@@ -32,10 +32,6 @@ impl BitString<'_> {
     }
 
     pub fn bits_amount(&self) -> usize {
-        if self.octets.is_empty() {
-            return 0;
-        }
-
         let data_len = self.octets.len() - 1;
         let padding = usize::from(self.octets[0]);
 

--- a/src/asn1/scheme/strings.rs
+++ b/src/asn1/scheme/strings.rs
@@ -1,13 +1,15 @@
-use crate::asn1::node_options::NodeOptions;
-use crate::asn1::scheme::build_asn1_schema;
-use crate::asn1::HighlightAction;
-use crate::common::RcSlice;
+use std::fmt::Write;
+
 use asn1_parser::{
     OwnedBitString, OwnedBmpString, OwnedGeneralString, OwnedIA5String, OwnedNumericString, OwnedOctetString,
     OwnedPrintableString, OwnedRawAsn1EntityData, OwnedUtf8String, OwnedVisibleString,
 };
-use std::fmt::Write;
 use yew::{function_component, html, Callback, Html, Properties};
+
+use crate::asn1::node_options::NodeOptions;
+use crate::asn1::scheme::build_asn1_schema;
+use crate::asn1::HighlightAction;
+use crate::common::RcSlice;
 
 #[derive(PartialEq, Properties, Clone)]
 pub struct OctetStringNodeProps {
@@ -81,11 +83,7 @@ pub fn bit_string(props: &BitStringNodeProps) -> Html {
         String::new()
     };
 
-    let display_bits = if bits.len() >= bits_amount {
-        &bits[0..bits_amount]
-    } else {
-        &bits[..]
-    };
+    let display_bits = &bits[0..bits_amount.min(bits.len())];
 
     let offset = props.meta.tag_position();
     let length_len = props.meta.length_range().len();

--- a/src/asn1/scheme/strings.rs
+++ b/src/asn1/scheme/strings.rs
@@ -1,13 +1,13 @@
-use asn1_parser::{
-    OwnedBitString, OwnedBmpString, OwnedGeneralString, OwnedIA5String, OwnedNumericString, OwnedOctetString,
-    OwnedPrintableString, OwnedRawAsn1EntityData, OwnedUtf8String, OwnedVisibleString,
-};
-use yew::{function_component, html, Callback, Html, Properties};
-
 use crate::asn1::node_options::NodeOptions;
 use crate::asn1::scheme::build_asn1_schema;
 use crate::asn1::HighlightAction;
 use crate::common::RcSlice;
+use asn1_parser::{
+    OwnedBitString, OwnedBmpString, OwnedGeneralString, OwnedIA5String, OwnedNumericString, OwnedOctetString,
+    OwnedPrintableString, OwnedRawAsn1EntityData, OwnedUtf8String, OwnedVisibleString,
+};
+use std::fmt::Write;
+use yew::{function_component, html, Callback, Html, Properties};
 
 #[derive(PartialEq, Properties, Clone)]
 pub struct OctetStringNodeProps {
@@ -68,15 +68,24 @@ pub struct BitStringNodeProps {
 
 #[function_component(BitStringNode)]
 pub fn bit_string(props: &BitStringNodeProps) -> Html {
-    let bits = props.node.raw_bits()[1..]
-        .iter()
-        .map(|byte| format!("{:08b}", byte))
-        .fold(String::new(), |mut ac, new| {
-            ac.push_str(&new);
-            ac
-        });
+    let raw_bits = props.node.raw_bits();
     let bits_amount = props.node.bits_amount();
-    let bits = &bits[0..bits_amount];
+
+    let bits = if raw_bits.len() > 1 {
+        let mut bits = String::with_capacity((raw_bits.len() - 1) * 8);
+        for byte in &raw_bits[1..] {
+            write!(bits, "{:08b}", byte).unwrap();
+        }
+        bits
+    } else {
+        String::new()
+    };
+
+    let display_bits = if bits.len() >= bits_amount {
+        &bits[0..bits_amount]
+    } else {
+        &bits[..]
+    };
 
     let offset = props.meta.tag_position();
     let length_len = props.meta.length_range().len();
@@ -99,7 +108,7 @@ pub fn bit_string(props: &BitStringNodeProps) -> Html {
                 <div class="terminal-asn1-node">
                     <NodeOptions node_bytes={RcSlice::from(props.meta.raw_bytes())} {offset} {length_len} {data_len} name={String::from("BitString")} />
                     <span class="asn1-node-info-label">{format!("({} bits)", bits_amount)}</span>
-                    <span class="asn-simple-value">{bits}</span>
+                    <span class="asn-simple-value">{display_bits}</span>
                 </div>
             }
         }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/aa82ed8d-4c55-465a-b0bb-ffa06d8b128c)

This pull request introduces a validation check in the BitString decoder to explicitly reject any BitString with no content bytes

### Test string
```sh
6065060a2a864886f7120102020303007e553053a003020105a10302011ea411180f32303235303230383130333035365aa5050203056b0ea603020129a9091b075442542e434f4daa1d301ba003020101a11430121b1077696e2d39353663716f73736a746624
```

closes #88 