### PR TITLE
Fix(issue-90): Remove removing last symbol from changes

### DIFF
--- a/src/diff/diff_viewer.rs
+++ b/src/diff/diff_viewer.rs
@@ -81,7 +81,7 @@ fn render_changes(diff: &DiffData) -> Vec<VNode> {
             <span class="diff-line-number">{"1"}</span>
         },
     );
-    let _ = changes.remove(changes.len() - 1);
+
     changes
 }
 


### PR DESCRIPTION
Delete a row, which removes the last symbol from the changes

What was the purpose of it?
![image](https://github.com/user-attachments/assets/4357a3fb-55fa-4153-9dd5-d6509700f62c)

closes #90 